### PR TITLE
feat(cli): added fabrik8 cli override complete nested objects and arrays

### DIFF
--- a/spec/reconcile.spec.js
+++ b/spec/reconcile.spec.js
@@ -368,7 +368,7 @@ describe('reconciler', () => {
         }
       }
       const argv = {
-        'arg-a': 2,
+        'arg-a': 'a',
         'arg-tokens.e': 2,
         'arg-cluster.g.h': 2
       }
@@ -376,7 +376,7 @@ describe('reconciler', () => {
 
       result.should.eql({
         common: {
-          a: 2,
+          a: 'a',
           b: 1,
           c: {
             d: 1
@@ -390,6 +390,24 @@ describe('reconciler', () => {
           g: {
             h: 2
           }
+        }
+      })
+    })
+
+    it('should override complete objects and arrays', async () => {
+      const input = {
+        common: {
+          a: 1
+        }
+      }
+      const argv = {
+        'arg-a': '["a"]'
+      }
+      const result = _yargsOverrides(input, argv)
+
+      result.should.eql({
+        common: {
+          a: [ 'a' ]
         }
       })
     })

--- a/src/reconcile.js
+++ b/src/reconcile.js
@@ -254,7 +254,11 @@ module.exports = function (clusterInfo, uuid = require('uuid')) {
       obj = obj[path[i]]
       if (!obj) return
     }
-    obj[path[i]] = val
+    try {
+      obj[path[i]] = JSON.parse(val)
+    } catch (e) {
+      obj[path[i]] = val
+    }
   }
 
   // we scrub full credential objects from the cluster data before saving, so


### PR DESCRIPTION
# Summary

Allows the override of complete nested objects and arrays using `--arg-`, for example `--arg-zones "[\"us-west2-a\"]"` will allow configuration of the cluster zone.